### PR TITLE
Add tests for display_size

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -30,3 +30,18 @@ pub(crate) fn pretty_print_float_slice(f: &mut fmt::Formatter<'_>, v: &[f64]) ->
     }
     writeln!(f, "]")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::display_size;
+
+    #[test]
+    fn test_display_size_zero() {
+        assert_eq!(display_size(0), "0B");
+    }
+
+    #[test]
+    fn test_display_size_one_kb() {
+        assert_eq!(display_size(8 * 1024), "1 KB");
+    }
+}


### PR DESCRIPTION
## Summary
- add module unit tests in `src/utils.rs`
- check `display_size` outputs for 0 bits and for 8k bits

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685c7f7755d88332b3e1d559cf78b1f4