### PR TITLE
Fix clone derive placement

### DIFF
--- a/src/stir.rs
+++ b/src/stir.rs
@@ -12,7 +12,8 @@ use crate::{
 };
 
 /// Parameters parametrizing an instance of STIR.
-/// This does not include the entire configuration of STIR, as we populate that later on according to required security config.#[derive(Clone)]
+/// This does not include the entire configuration of STIR, as we populate that later on according to required security config.
+#[derive(Clone)]
 pub struct StirParameters {
     /// The starting rate used in the protocol.
     pub starting_log_inv_rate: usize,

--- a/src/whir.rs
+++ b/src/whir.rs
@@ -12,7 +12,8 @@ use crate::{
 };
 
 /// Parameters parametrizing an instance of WHIR.
-/// This does not include the entire configuration of WHIR, as we populate that later on according to required security config.#[derive(Clone)]
+/// This does not include the entire configuration of WHIR, as we populate that later on according to required security config.
+#[derive(Clone)]
 pub struct WhirParameters {
     /// The starting rate used in the protocol.
     pub starting_log_inv_rate: usize,


### PR DESCRIPTION
## Summary
- place `#[derive(Clone)]` on `StirParameters` and `WhirParameters`
- clean stray attribute text from documentation comments

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_b_685c7f70de9083329a9fab9408f12673