### PR TITLE
Remove dead code comments

### DIFF
--- a/src/whir.rs
+++ b/src/whir.rs
@@ -217,7 +217,6 @@ impl WhirProtocol {
             current_log_degree -= 1;
         }
 
-
         let mut round_parameters = Vec::with_capacity(num_rounds);
 
         for (i, (folding_factor, next_rate)) in whir_parameters
@@ -236,10 +235,9 @@ impl WhirProtocol {
                 1 << folding_factor,
                 true,
             );
-            protocol_builder = protocol_builder
-                .prover_message(ProverMessage::new(ProofElement::MerkleRoot(
-                    next_merkle_tree,
-                )));
+            protocol_builder = protocol_builder.prover_message(ProverMessage::new(
+                ProofElement::MerkleRoot(next_merkle_tree),
+            ));
 
             // Compute the ood samples required
             let ood_samples = whir_parameters.security_assumption.determine_ood_samples(

--- a/src/whir.rs
+++ b/src/whir.rs
@@ -216,7 +216,7 @@ impl WhirProtocol {
             starting_folding_pow_bits_vec.push(starting_folding_pow_bits);
             current_log_degree -= 1;
         }
-        //protocol_builder = protocol_builder.end_round();
+
 
         let mut round_parameters = Vec::with_capacity(num_rounds);
 
@@ -237,7 +237,6 @@ impl WhirProtocol {
                 true,
             );
             protocol_builder = protocol_builder
-                //.start_round("stir_iteration")
                 .prover_message(ProverMessage::new(ProofElement::MerkleRoot(
                     next_merkle_tree,
                 )));


### PR DESCRIPTION
## Summary
- clean up `WhirProtocol` by removing outdated commented-out code lines

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_685c7e4a86a883328d3260e0cbdfda0e