### PR TITLE
Fix inner comments to start with lowercase

### DIFF
--- a/src/basefold.rs
+++ b/src/basefold.rs
@@ -119,7 +119,7 @@ impl BasefoldProtocol {
                 basefold_parameters.starting_log_inv_rate,
                 ldt_parameters.field.extension_bit_size(),
                 ldt_parameters.batch_size,
-            ); // We now start, the initial folding pow bits
+            ); // we now start, the initial folding pow bits
             batching_pow_bits = pow_util(security_level, prox_gaps_error_batching);
 
             // Add the round for the batching
@@ -137,7 +137,7 @@ impl BasefoldProtocol {
             starting_domain_log_size - starting_folding_factor,
             ldt_parameters.field,
             (1 << starting_folding_factor) * ldt_parameters.batch_size,
-            false, // First tree is over the base
+            false, // first tree is over the base
         );
         let mut commitments = vec![starting_merkle_tree];
 
@@ -146,7 +146,7 @@ impl BasefoldProtocol {
         let mut starting_folding_pow_bits_vec = Vec::with_capacity(starting_folding_factor);
         protocol_builder = protocol_builder.start_round("initial_iteration");
         for _ in 0..starting_folding_factor {
-            // We now start, the initial folding pow bits
+            // we now start, the initial folding pow bits
             let prox_gaps_error = basefold_parameters.security_assumption.prox_gaps_error(
                 current_log_degree - 1,
                 basefold_parameters.starting_log_inv_rate,
@@ -209,7 +209,7 @@ impl BasefoldProtocol {
 
             let mut pow_bits_vec = Vec::with_capacity(folding_factor);
             for _ in 0..folding_factor {
-                // We now start, the initial folding pow bits
+                // we now start, the initial folding pow bits
                 let prox_gaps_error = basefold_parameters.security_assumption.prox_gaps_error(
                     current_log_degree - 1,
                     basefold_parameters.starting_log_inv_rate,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,13 +25,13 @@ impl SecurityAssumption {
     /// E.g. in JB proximity gaps holds for every δ ∈ (0, 1 - √ρ).
     /// η is the distance between the chosen proximity parameter and the bound.
     /// I.e. in JB δ = 1 - √ρ - η and in CB δ = 1 - ρ - η.
-    // TODO: Maybe it makes more sense to be multiplicative. I think this can be set in a better way.
+    // TODO: maybe it makes more sense to be multiplicative. I think this can be set in a better way.
     pub fn log_eta(&self, log_inv_rate: usize) -> f64 {
         // Ask me how I did this? At the time, only God and I knew. Now only God knows
         // I joke, I actually know but this is left for posterity.
         match self {
             // We don't use η in UD
-            Self::UniqueDecoding => 0., // TODO: Maybe just panic and avoid calling it in UD?
+            Self::UniqueDecoding => 0., // TODO: maybe just panic and avoid calling it in UD?
             // Set as √ρ/20
             Self::JohnsonBound => -(0.5 * log_inv_rate as f64 + LOG2_10 + 1.),
             // Set as ρ/20

--- a/src/fri.rs
+++ b/src/fri.rs
@@ -117,7 +117,7 @@ impl FriProtocol {
                 fri_parameters.starting_log_inv_rate,
                 ldt_parameters.field.extension_bit_size(),
                 ldt_parameters.batch_size,
-            ); // We now start, the initial folding pow bits
+            ); // we now start, the initial folding pow bits
             batching_pow_bits = pow_util(security_level, prox_gaps_error_batching);
 
             // Add the round for the batching
@@ -135,14 +135,14 @@ impl FriProtocol {
             starting_domain_log_size - starting_folding_factor,
             ldt_parameters.field,
             (1 << starting_folding_factor) * ldt_parameters.batch_size,
-            false, // First tree is over the base
+            false, // first tree is over the base
         );
         let mut commitments = vec![starting_merkle_tree];
 
         // Degree of next polynomial to send
         let mut current_log_degree = ldt_parameters.log_degree - starting_folding_factor;
 
-        // We now start, the initial folding pow bits
+        // we now start, the initial folding pow bits
         let starting_folding_prox_gaps_error = fri_parameters.security_assumption.prox_gaps_error(
             current_log_degree,
             fri_parameters.starting_log_inv_rate,

--- a/src/protocol/proof_size.rs
+++ b/src/protocol/proof_size.rs
@@ -55,7 +55,7 @@ impl MerkleTree {
                 is_extension,
             },
             tree_depth,
-            digest_size: 256, // TODO: We might change this based on security level
+            digest_size: 256, // TODO: we might change this based on security level
         }
     }
 }

--- a/src/stir.rs
+++ b/src/stir.rs
@@ -150,7 +150,7 @@ impl StirProtocol {
                 stir_parameters.starting_log_inv_rate,
                 ldt_parameters.field.extension_bit_size(),
                 ldt_parameters.batch_size,
-            ); // We now start, the initial folding pow bits
+            ); // we now start, the initial folding pow bits
             batching_pow_bits = pow_util(security_level, prox_gaps_error_batching);
 
             // Add the round for the batching
@@ -168,14 +168,14 @@ impl StirProtocol {
             starting_domain_log_size - starting_folding_factor,
             ldt_parameters.field,
             (1 << starting_folding_factor) * ldt_parameters.batch_size,
-            false, // First tree is over the base
+            false, // first tree is over the base
         );
 
         // Degree of next polynomial to send
         let mut current_log_degree = ldt_parameters.log_degree - starting_folding_factor;
         let mut log_inv_rate = stir_parameters.starting_log_inv_rate;
 
-        // We now start, the initial folding pow bits
+        // we now start, the initial folding pow bits
         let starting_folding_prox_gaps_error = stir_parameters.security_assumption.prox_gaps_error(
             current_log_degree,
             log_inv_rate,

--- a/src/whir.rs
+++ b/src/whir.rs
@@ -147,7 +147,7 @@ impl WhirProtocol {
                 whir_parameters.starting_log_inv_rate,
                 ldt_parameters.field.extension_bit_size(),
                 ldt_parameters.batch_size,
-            ); // We now start, the initial folding pow bits
+            ); // we now start, the initial folding pow bits
             batching_pow_bits = pow_util(security_level, prox_gaps_error_batching);
 
             // Add the round for the batching
@@ -165,7 +165,7 @@ impl WhirProtocol {
             starting_domain_log_size - starting_folding_factor,
             ldt_parameters.field,
             (1 << starting_folding_factor) * ldt_parameters.batch_size,
-            false, // First tree is over the base
+            false, // first tree is over the base
         );
 
         // Degree of next polynomial to send
@@ -177,7 +177,7 @@ impl WhirProtocol {
 
         protocol_builder = protocol_builder.start_round("whir_iteration");
         for _ in 0..whir_parameters.starting_folding_factor {
-            // We now start, the initial folding pow bits
+            // we now start, the initial folding pow bits
             let prox_gaps_error = whir_parameters.security_assumption.prox_gaps_error(
                 current_log_degree - 1,
                 log_inv_rate,
@@ -320,7 +320,7 @@ impl WhirProtocol {
 
             let mut pow_bits_vec = Vec::with_capacity(folding_factor);
             for _ in 0..folding_factor {
-                // We now start, the initial folding pow bits
+                // we now start, the initial folding pow bits
                 let prox_gaps_error = whir_parameters.security_assumption.prox_gaps_error(
                     current_log_degree - 1,
                     next_rate,


### PR DESCRIPTION
## Summary
- tweak inline comment casing across protocols and utilities
- keep TODO items in lower case

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings` *(fails: 'cargo-clippy' is not installed)*
- `cargo build --verbose`
- `cargo test --verbose`

------
https://chatgpt.com/codex/tasks/task_b_685c8390c76883328768538e60f422fe